### PR TITLE
Set stderr level to INFO in redirect_stdout_to_logger

### DIFF
--- a/src/internet_archive_downloader.py
+++ b/src/internet_archive_downloader.py
@@ -210,6 +210,8 @@ def download_single_url(url: str, start_date: str, end_date: str, download_reset
     if download_reset:
         logger.info("Download reset is enabled.")
 
+    # PyWayBackup writes normal progress messages (e.g., "process cdx") to stderr,
+    # so map stderr to INFO here to avoid false ERROR logs.
     with redirect_stdout_to_logger(logger, stderr_level=logging.INFO):
         backup = PyWayBackup(
             url=url,

--- a/src/internet_archive_downloader.py
+++ b/src/internet_archive_downloader.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import os
 import shutil
 import re
+import logging
 
 from pywaybackup import PyWayBackup
 from pywaybackup.helper import sanitize_filename
@@ -209,7 +210,7 @@ def download_single_url(url: str, start_date: str, end_date: str, download_reset
     if download_reset:
         logger.info("Download reset is enabled.")
 
-    with redirect_stdout_to_logger(logger):
+    with redirect_stdout_to_logger(logger, stderr_level=logging.INFO):
         backup = PyWayBackup(
             url=url,
             all=True,


### PR DESCRIPTION
Made a quick fix here to address all the "ERRORS" shown in the log while populating the CDX index. 

I fixed this quickly thereby not addressing that there is some kind of naming issue here (stderr_level = INFO) due to some code structure we could refactor when we have time. I clearly see why it is like this - because PyWayBackup writes diagnostic output to stderr (not actual errors), but the function design assumes stderr = errors. I put in a small comment above the code and then we can fix it probably on a rainy day as all works as intended for now.