### PR TITLE
Fetch outgoing links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Outgoing-link archiving (`warc_outlinks.py`): after each primary WARC is created, outgoing `<a>` hyperlinks and embedded resources (images, scripts, stylesheets, frames, media, objects) are extracted from every archived HTML page, downloaded from the Wayback Machine at the capture date of the referencing page, and packaged into a separate `<name>_outlinks-XXXX.warc.gz` file
+- `--no-outlinks` flag to skip the outgoing-link archiving step
+
 ## [0.0.11] - 2026-03-10
 
 ### Added

--- a/src/internet_archive_downloader.py
+++ b/src/internet_archive_downloader.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import glob
 import os
 import shutil
 import re
@@ -8,6 +9,7 @@ from pywaybackup import PyWayBackup
 from pywaybackup.helper import sanitize_filename
 from wayback_date_object import WaybackDateObject
 from waybackup_to_warc import process_csv_file
+from warc_outlinks import fetch_and_archive_outlinks
 from constants import Period
 from sqlalchemy.exc import OperationalError
 from sqlalchemy import create_engine, inspect, text
@@ -44,7 +46,7 @@ def get_wayback_date_and_archived_url(wayback_url: str):
         return None, wayback_url
 
 
-def download_urls_from_csv(csv_file_path: str, url_column_name: str, start_time: str = None, end_time: str = None, download_period: Period = None, download_reset: bool = False, dir_cleanup: bool = False, workers: int = None, snapshot_folder: str = "./waybackup_snapshots", warc_output: str = "./output"):
+def download_urls_from_csv(csv_file_path: str, url_column_name: str, start_time: str = None, end_time: str = None, download_period: Period = None, download_reset: bool = False, dir_cleanup: bool = False, workers: int = None, snapshot_folder: str = "./waybackup_snapshots", warc_output: str = "./output", fetch_outlinks: bool = True):
     """
     Reads a CSV file containing Internet Archive URLs (eg. https://web.archive.org/web/20251002062751/https://cas.au.dk/erc-webchild),
     retrieves their corresponding Wayback Machine archived URLs and dates, and downloads the archived content for each URL for a period of two weeks around the archived date.
@@ -58,6 +60,9 @@ def download_urls_from_csv(csv_file_path: str, url_column_name: str, start_time:
         download_reset (bool, optional): Whether to reset downloads. Defaults to False.
         snapshot_folder (str, optional): Path to the snapshot folder. Defaults to "./waybackup_snapshots".
         warc_output (str, optional): Path to the WARC output folder. Defaults to "./output".
+        fetch_outlinks (bool, optional): If True, after each WARC is created, download the
+            outgoing links found in its archived pages and package them into a separate
+            "<name>_outlinks" WARC. Defaults to True.
 
     Returns:
         None
@@ -128,6 +133,10 @@ def download_urls_from_csv(csv_file_path: str, url_column_name: str, start_time:
 
             process_csv_file(os.path.join(snapshot_folder, waybackup_filename), warc_output,  warcfile_name)
 
+            # Fetch and archive outgoing links from the freshly created WARC files
+            if fetch_outlinks:
+                create_outlinks_warc(warc_output, warcfile_name)
+
             drop_snapshot_indexes(snapshot_folder)
             copy_log_files(snapshot_folder)
             if dir_cleanup:
@@ -162,6 +171,32 @@ def create_waybackup_filename(archived_url):
     sanitized = sanitize_filename(archived_url)
     sanitized = re.sub(r'([^\w\s])\1+', r'\1', sanitized)
     return f"waybackup_{sanitized}.csv"
+
+def create_outlinks_warc(warc_output: str, warcfile_name: str):
+    """
+    Finds the WARC files just created for a source URL and archives their outgoing links.
+
+    Locates every "<warcfile_name>-XXXX.warc.gz" part file in the output folder, extracts
+    the outgoing links from the archived HTML pages, downloads each linked resource from
+    the Wayback Machine using the same capture date as the referencing page, and packages
+    the results into a separate "<warcfile_name>_outlinks-XXXX.warc.gz" WARC file.
+
+    Args:
+        warc_output (str): Path to the WARC output folder.
+        warcfile_name (str): Base name of the source WARC file(s) (without the "-XXXX" suffix).
+
+    Returns:
+        None
+    """
+    pattern = os.path.join(warc_output, f"{warcfile_name}-*.warc.gz")
+    source_warcs = sorted(glob.glob(pattern))
+
+    if not source_warcs:
+        logger.warning(f"No WARC files found for outgoing-link extraction: {pattern}")
+        return
+
+    logger.info(f"Archiving outgoing links from {len(source_warcs)} WARC file(s) for '{warcfile_name}'.")
+    fetch_and_archive_outlinks(source_warcs, warc_output, warcfile_name)
 
 def cleanup_temporary_files(snapshot_folder: str = "./waybackup_snapshots"):
     """

--- a/src/main.py
+++ b/src/main.py
@@ -23,6 +23,7 @@ parser.add_argument("--clean", action="store_true", help="If set, deletes the in
 parser.add_argument("--workers", type=int, default=5, help="Number of worker threads to use for downloading. Default is 5.")
 parser.add_argument("--snapshot-folder", default="./waybackup_snapshots", help="Path to the snapshot folder where pywaybackup stores downloaded files. Default is './waybackup_snapshots'.")
 parser.add_argument("--warc-output", default="./output", help="Path to the output folder where WARC files will be stored. Default is './output'.")
+parser.add_argument("--no-outlinks", action="store_true", help="If set, skips the step that downloads and archives the outgoing links found in the created WARC files.")
 parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help="Set the logging level. Default is INFO.")
 parser.add_argument("--log-file", help="Path to a log file. If not specified, logs only to console.")
 
@@ -65,6 +66,7 @@ def choose_mode():
     workers = args.workers
     snapshot_folder = args.snapshot_folder
     warc_output = args.warc_output
+    fetch_outlinks = not args.no_outlinks
 
     if download_period == Period.CUSTOM:
         logger.info("CUSTOM period selected.")
@@ -74,7 +76,7 @@ def choose_mode():
 
     if args.mode.upper() == Mode.DOWNLOAD.name:
         logger.info("Download mode selected.")
-        download_urls_from_csv(args.input, args.column_name, args.start_time, args.end_time, download_period, download_reset, dir_cleanup, workers, snapshot_folder, warc_output)
+        download_urls_from_csv(args.input, args.column_name, args.start_time, args.end_time, download_period, download_reset, dir_cleanup, workers, snapshot_folder, warc_output, fetch_outlinks)
     elif args.mode.upper() == Mode.CONVERT.name:
         logger.info("Convert mode selected.")
         combine_csv_files(args.input, COMBINED_CSV_PATH)

--- a/src/warc_outlinks.py
+++ b/src/warc_outlinks.py
@@ -1,0 +1,342 @@
+"""
+Outgoing-link archiving step.
+
+After the primary WARC files have been created, this module walks through those
+WARC files, extracts the outgoing links (``<a href>`` targets) and embedded
+resources (images, scripts, stylesheets, frames, media, objects) from every
+archived HTML page, downloads each one from the Wayback Machine using the *same*
+capture date as the page that referenced it, and packages everything into a
+separate, properly named WARC file (``<basename>_outlinks-XXXX.warc.gz``).
+"""
+
+import os
+import re
+import time
+from io import BytesIO
+from datetime import datetime
+from html.parser import HTMLParser
+from urllib.parse import urljoin, urldefrag, urlparse
+
+import requests
+from warcio.archiveiterator import ArchiveIterator
+from warcio.warcwriter import WARCWriter
+from warcio.statusandheaders import StatusAndHeaders
+
+from logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Wayback "id_" modifier returns the raw archived resource without rewriting or toolbar.
+WAYBACK_RAW_URL = "https://web.archive.org/web/{timestamp}id_/{url}"
+DEFAULT_USER_AGENT = "InternetArchiveExtractor/0.0.11 (+outlinks)"
+
+# Matches the 14-digit capture timestamp in a Wayback URL (e.g. /web/20000302202605/...).
+_WAYBACK_TS_RE = re.compile(r"/web/(\d{14})")
+# Schemes that are not fetchable resources and should be ignored.
+_SKIP_SCHEMES = {"mailto", "javascript", "tel", "data", "ftp", "file"}
+
+
+# For each HTML tag, the attribute(s) that hold a fetchable URL. Covers both
+# outgoing hyperlinks (<a href>) and embedded resources (images, scripts,
+# stylesheets, frames, media, objects).
+_URL_ATTRS = {
+    "a": ("href",),
+    "area": ("href",),
+    "img": ("src",),
+    "script": ("src",),
+    "link": ("href",),
+    "iframe": ("src",),
+    "frame": ("src",),
+    "source": ("src",),
+    "embed": ("src",),
+    "video": ("src", "poster"),
+    "audio": ("src",),
+    "object": ("data",),
+}
+
+
+class _LinkExtractor(HTMLParser):
+    """Collects outgoing hyperlinks and embedded-resource URLs from an HTML document."""
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.links = []
+
+    def handle_starttag(self, tag, attrs):
+        url_attrs = _URL_ATTRS.get(tag)
+        if not url_attrs:
+            return
+        for name, value in attrs:
+            if name in url_attrs and value:
+                self.links.append(value)
+
+
+def extract_outgoing_links(html_bytes, base_url):
+    """
+    Parse an HTML document and return a de-duplicated, order-preserving list of
+    absolute URLs to fetch: outgoing ``<a>`` hyperlinks plus embedded resources
+    (images, scripts, stylesheets, frames, media, objects).
+
+    Relative links are resolved against ``base_url`` (the page's original URL).
+    Fragments are stripped and non-HTTP(S) schemes are discarded.
+    """
+    text = html_bytes.decode("utf-8", errors="replace")
+    parser = _LinkExtractor()
+    try:
+        parser.feed(text)
+    except Exception as e:  # malformed markup should never abort the run
+        logger.debug(f"HTML parse error for {base_url}: {e}")
+
+    links = []
+    seen = set()
+    for href in parser.links:
+        href = href.strip()
+        if not href or href.startswith("#"):
+            continue
+        if urlparse(href).scheme.lower() in _SKIP_SCHEMES:
+            continue
+        absolute, _ = urldefrag(urljoin(base_url, href))
+        if not urlparse(absolute).scheme.lower().startswith("http"):
+            continue
+        if absolute not in seen:
+            seen.add(absolute)
+            links.append(absolute)
+    return links
+
+
+def _warc_date_to_timestamp(warc_date):
+    """Convert a WARC-Date ('2000-03-02T20:26:05Z') to a Wayback timestamp ('20000302202605')."""
+    try:
+        return datetime.strptime(warc_date, "%Y-%m-%dT%H:%M:%SZ").strftime("%Y%m%d%H%M%S")
+    except (TypeError, ValueError):
+        return None
+
+
+def _timestamp_to_warc_date(timestamp):
+    """Convert a Wayback timestamp ('20000302202605') to a WARC-Date ('2000-03-02T20:26:05Z')."""
+    try:
+        return datetime.strptime(timestamp, "%Y%m%d%H%M%S").strftime("%Y-%m-%dT%H:%M:%SZ")
+    except (TypeError, ValueError):
+        return None
+
+
+def collect_outlinks_from_warcs(source_warc_paths):
+    """
+    Walk through the given WARC files and gather every outgoing link found in the
+    archived HTML pages.
+
+    Returns a dict mapping ``absolute_url -> wayback_timestamp`` (the capture date of
+    the page that linked to it). Links that point to pages already captured in the
+    source WARC files are excluded so they are not downloaded twice.
+    """
+    outlinks = {}
+    known_urls = set()
+
+    for warc_path in source_warc_paths:
+        logger.debug(f"Scanning for outgoing links: {warc_path}")
+        with open(warc_path, "rb") as stream:
+            for record in ArchiveIterator(stream):
+                if record.rec_type != "response":
+                    continue
+
+                target_uri = record.rec_headers.get_header("WARC-Target-URI")
+                if target_uri:
+                    known_urls.add(target_uri)
+
+                content_type = (
+                    record.http_headers.get_header("Content-Type")
+                    if record.http_headers else None
+                )
+                if not content_type or "html" not in content_type.lower():
+                    continue
+
+                timestamp = _warc_date_to_timestamp(
+                    record.rec_headers.get_header("WARC-Date")
+                )
+                if timestamp is None:
+                    logger.debug(f"No usable capture date for {target_uri}; skipping its links.")
+                    continue
+
+                payload = record.content_stream().read()
+                if not payload:
+                    continue
+
+                for link in extract_outgoing_links(payload, target_uri):
+                    # Keep the first (earliest-seen) timestamp for each unique URL.
+                    outlinks.setdefault(link, timestamp)
+
+    # Don't re-fetch pages that are already present in the source archive.
+    for url in known_urls:
+        outlinks.pop(url, None)
+
+    return outlinks
+
+
+def _download_archived_resource(url, timestamp, session, user_agent, timeout, max_retries):
+    """
+    Fetch a single resource from the Wayback Machine at the given capture date.
+
+    Returns the ``requests.Response`` (after following redirects to the nearest
+    snapshot) or ``None`` if the request could not be completed.
+    """
+    request_url = WAYBACK_RAW_URL.format(timestamp=timestamp, url=url)
+    for attempt in range(max_retries + 1):
+        try:
+            response = session.get(
+                request_url,
+                headers={"User-Agent": user_agent},
+                timeout=timeout,
+                allow_redirects=True,
+            )
+        except requests.RequestException as e:
+            logger.debug(f"Request error for {request_url} (attempt {attempt + 1}): {e}")
+            response = None
+
+        # Back off and retry on throttling / transient server errors.
+        if response is not None and response.status_code not in (429,) and response.status_code < 500:
+            return response
+        if attempt < max_retries:
+            time.sleep(2 ** attempt)
+
+    if response is not None:
+        return response
+    return None
+
+
+def _actual_capture_timestamp(response, requested_timestamp):
+    """Prefer the real snapshot timestamp from the redirected URL, falling back to the requested one."""
+    match = _WAYBACK_TS_RE.search(response.url or "")
+    return match.group(1) if match else requested_timestamp
+
+
+def fetch_and_archive_outlinks(
+    source_warc_paths,
+    output_dir,
+    output_basename,
+    *,
+    delay=0.1,
+    timeout=30,
+    max_retries=2,
+    user_agent=DEFAULT_USER_AGENT,
+    max_size_bytes=1073741824,
+):
+    """
+    End-to-end outgoing-link archiving for one set of source WARC files.
+
+    Collects outgoing links from ``source_warc_paths``, downloads each one from the
+    Wayback Machine at the capture date of the referencing page, and writes the
+    results to ``<output_dir>/<output_basename>_outlinks-XXXX.warc.gz``.
+
+    Args:
+        source_warc_paths (list[str]): WARC files to extract outgoing links from.
+        output_dir (str): Directory the outlinks WARC file(s) are written to.
+        output_basename (str): Base name of the source WARC (without the ``-XXXX`` suffix).
+        delay (float): Politeness delay in seconds between requests to the Wayback Machine.
+        timeout (int): Per-request timeout in seconds.
+        max_retries (int): Retries on throttling / transient server errors.
+        user_agent (str): User-Agent header sent with each request.
+        max_size_bytes (int): Size threshold at which a new WARC part file is started.
+    """
+    outlinks = collect_outlinks_from_warcs(source_warc_paths)
+    if not outlinks:
+        logger.info(f"No outgoing links found for '{output_basename}'. Skipping outlinks WARC.")
+        return
+
+    logger.info(f"Found {len(outlinks)} unique outgoing link(s) for '{output_basename}'. Downloading...")
+
+    output_filename = f"{output_basename}_outlinks"
+    writer_state = _OutlinksWarcWriter(output_dir, output_filename, max_size_bytes)
+
+    session = requests.Session()
+    success = 0
+    failed = 0
+    try:
+        for index, (url, timestamp) in enumerate(outlinks.items(), start=1):
+            if index % 100 == 0:
+                logger.debug(f"Outlink progress: {index}/{len(outlinks)}")
+
+            response = _download_archived_resource(
+                url, timestamp, session, user_agent, timeout, max_retries
+            )
+            if response is None:
+                failed += 1
+            else:
+                capture_ts = _actual_capture_timestamp(response, timestamp)
+                writer_state.write_resource(
+                    url=url,
+                    status_code=response.status_code,
+                    reason=response.reason or "",
+                    content_type=response.headers.get("Content-Type", "application/octet-stream"),
+                    content=response.content,
+                    warc_date=_timestamp_to_warc_date(capture_ts),
+                )
+                success += 1
+
+            if delay:
+                time.sleep(delay)
+    finally:
+        writer_state.close()
+        session.close()
+
+    logger.info(
+        f"\nOutlinks WARC summary for '{output_basename}':\n"
+        f"  Links downloaded:   {success}\n"
+        f"  Links failed:       {failed}\n"
+        f"  Total outgoing:     {len(outlinks)}\n"
+        f"  WARC part files:    {writer_state.file_number}"
+    )
+
+
+class _OutlinksWarcWriter:
+    """Writes downloaded resources to one or more size-bounded ``.warc.gz`` part files."""
+
+    def __init__(self, output_dir, output_filename, max_size_bytes):
+        self.output_dir = output_dir
+        self.output_filename = output_filename
+        self.max_size_bytes = max_size_bytes
+        self.file_number = 1
+        self.current_size = 0
+        os.makedirs(output_dir, exist_ok=True)
+        self._open_new_file()
+
+    def _current_path(self):
+        return os.path.join(
+            self.output_dir, f"{self.output_filename}-{self.file_number:04d}.warc.gz"
+        )
+
+    def _open_new_file(self):
+        self.warc_path = self._current_path()
+        logger.info(f"Creating outlinks WARC file: {self.warc_path}")
+        self.stream = open(self.warc_path, "wb")
+        self.writer = WARCWriter(self.stream, gzip=True)
+
+    def write_resource(self, url, status_code, reason, content_type, content, warc_date):
+        if self.current_size >= self.max_size_bytes:
+            self.stream.close()
+            logger.info(
+                f"Completed outlinks WARC file: {self.warc_path} "
+                f"(Size: {self.current_size / (1024 ** 3):.2f} GB)"
+            )
+            self.file_number += 1
+            self.current_size = 0
+            self._open_new_file()
+
+        http_headers = StatusAndHeaders(
+            f"{status_code} {reason}".strip(),
+            [("Content-Type", content_type)],
+            protocol="HTTP/1.0",
+        )
+        record = self.writer.create_warc_record(
+            url,
+            "response",
+            payload=BytesIO(content),
+            length=len(content),
+            http_headers=http_headers,
+            warc_headers_dict={"WARC-Date": warc_date} if warc_date else None,
+        )
+        self.writer.write_record(record)
+        self.current_size += len(content)
+
+    def close(self):
+        self.stream.close()
+        logger.debug(f"Completed outlinks WARC file: {self.warc_path}")

--- a/src/warc_outlinks.py
+++ b/src/warc_outlinks.py
@@ -221,7 +221,7 @@ def fetch_and_archive_outlinks(
     max_size_bytes=1073741824,
 ):
     """
-    End-to-end outgoing-link archiving for one set of source WARC files.
+    End-to-end outgoing-link archiving for a set of WARC files.
 
     Collects outgoing links from ``source_warc_paths``, downloads each one from the
     Wayback Machine at the capture date of the referencing page, and writes the
@@ -229,7 +229,7 @@ def fetch_and_archive_outlinks(
 
     Args:
         source_warc_paths (list[str]): WARC files to extract outgoing links from.
-        output_dir (str): Directory the outlinks WARC file(s) are written to.
+        output_dir (str): Directory the downloaded resources are written to.
         output_basename (str): Base name of the source WARC (without the ``-XXXX`` suffix).
         delay (float): Politeness delay in seconds between requests to the Wayback Machine.
         timeout (int): Per-request timeout in seconds.

--- a/src/warc_outlinks.py
+++ b/src/warc_outlinks.py
@@ -198,8 +198,8 @@ def _download_archived_resource(url, timestamp, session, user_agent, timeout, ma
         if attempt < max_retries:
             time.sleep(2 ** attempt)
 
-    if response is not None:
-        return response
+    # Retries exhausted: a final throttled/5xx response is a failure, not a
+    # resource worth archiving, so don't write it into the outlinks WARC.
     return None
 
 
@@ -339,4 +339,7 @@ class _OutlinksWarcWriter:
 
     def close(self):
         self.stream.close()
-        logger.debug(f"Completed outlinks WARC file: {self.warc_path}")
+        logger.info(
+            f"Completed outlinks WARC file: {self.warc_path} "
+            f"(Size: {self.current_size / (1024 ** 3):.2f} GB)"
+        )


### PR DESCRIPTION
This branch adds *outgoing-link archiving* to the downloader.

After each primary WARC is created, the new *warc_outlinks.py* module: 
1. Scans the archived HTML pages for outgoing <a> links and embedded resources (images, scripts, stylesheets, frames, media, objects)
2. Downloads each one from the Wayback Machine at the same capture date as the page that referenced it (skipping URLs already in the source WARCs)
3. packages them into a separate, size-bounded <name>_outlinks-XXXX.warc.gz file

It's enabled by default and wired into the download flow via create_outlinks_warc in internet_archive_downloader.py

A new --no-outlinks CLI flag can be applied to skip the step. 