### PR TITLE
Add unittests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Outgoing-link archiving (`warc_outlinks.py`): after each primary WARC is created, outgoing `<a>` hyperlinks and embedded resources (images, scripts, stylesheets, frames, media, objects) are extracted from every archived HTML page, downloaded from the Wayback Machine at the capture date of the referencing page, and packaged into a separate `<name>_outlinks-XXXX.warc.gz` file
+- `--no-outlinks` flag to skip the outgoing-link archiving step
+- Full unit test suite (`tests/`) covering all source modules: `constants`, `utils`, `wayback_date_object`, `logging_config`, `waybackup_to_warc`, `warc_outlinks`, and `internet_archive_downloader` (106 tests, no network access required)
+- `pytest` added as an optional `test` dependency in `pyproject.toml`
+- Test running instructions added to README
+
 ## [0.0.11] - 2026-03-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -114,6 +114,37 @@ python src/main.py convert waybackup_snapshots --output mysite_archive --warc-ou
 - The CSVs are expected to contain columns: `url_origin`, `url_archive`, `file`, `timestamp`, and `response`.
 
 
+## Running the tests
+
+The unit tests live in the `tests/` directory and are run with [pytest](https://docs.pytest.org/).
+
+1. Install the test dependency (pytest is declared as an optional `test` dependency):
+
+   ```bash
+   pip install pytest
+   # or, to install the project with its test extra:
+   pip install -e ".[test]"
+   ```
+
+2. Run the full suite from the repository root:
+
+   ```bash
+   python -m pytest
+   ```
+
+Useful variations:
+
+```bash
+python -m pytest -v                                  # verbose, one line per test
+python -m pytest tests/test_waybackup_to_warc.py     # a single test file
+python -m pytest -k outlinks                          # only tests matching "outlinks"
+```
+
+The tests are configured in `pyproject.toml` (`[tool.pytest.ini_options]`), which
+adds `src/` to the Python path automatically — so you don't need to install the
+package to run them. The tests are self-contained and stub out all network and
+`pywaybackup` calls, so no internet access is required.
+
 ## Important implementation notes
 - **Automatic workflow in Download mode**: When downloading, each URL is processed individually:
   1. Downloads snapshots using `pywaybackup` to the snapshot folder (default: `waybackup_snapshots/`, configurable via `--snapshot-folder`)
@@ -163,5 +194,4 @@ This will:
 
 ## Next steps / Improvements
 - Add argument validation to require `--output` for `convert` mode
-- Add unit tests for CSV combining and WARC creation edge cases (missing files, bad timestamps)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,11 @@ internet-archive-extractor = "main:main"
 
 [project.urls]
 Homepage = "https://github.com/WEB-CHILD/InternetArchiveExtractor"
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = "-ra"

--- a/src/utils.py
+++ b/src/utils.py
@@ -12,17 +12,6 @@ def clean_urls(dataframe):
     dataframe['url_origin'] = dataframe['url_origin'].apply(lambda x: remove_port_80(x))
     return dataframe
 
-def create_warc_gz(file_path, dataframe):
-    from warcio.archiveiterator import ArchiveIterator
-    from warcio.warcwriter import WARCWriter
-    import gzip
-
-    with gzip.open(file_path, 'wb') as stream:
-        writer = WARCWriter(stream, gzip=True)
-        for index, row in dataframe.iterrows():
-            writer.write_webpage(row['url_origin'], row['timestamp'], content_type='text/html')
-            writer.write_webpage(row['url_archive'], row['timestamp'], content_type='text/html')
-
 def import_urls_from_csv(file_path, column_name):
     """
     Imports URLs from a specified column in a CSV file.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+"""Shared pytest fixtures and path setup.
+
+The package is installed *non-editable* and its modules import each other
+flat (``from waybackup_to_warc import ...``), so the tests run against the
+source of truth in ``src/`` by putting that directory on ``sys.path``.
+"""
+
+import os
+import sys
+
+import pytest
+
+SRC_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+
+@pytest.fixture
+def warc_bytes_factory():
+    """Return a helper that builds an in-memory ``.warc.gz`` byte string.
+
+    The helper accepts a list of ``(url, warc_date, content_type, body)``
+    tuples and writes one WARC ``response`` record per tuple.
+    """
+    import gzip
+    from io import BytesIO
+
+    from warcio.warcwriter import WARCWriter
+    from warcio.statusandheaders import StatusAndHeaders
+
+    def _make(records):
+        buf = BytesIO()
+        # WARCWriter(gzip=True) gzips each record individually, which is the
+        # same on-disk shape the production code produces.
+        writer = WARCWriter(buf, gzip=True)
+        for url, warc_date, content_type, body in records:
+            http_headers = StatusAndHeaders(
+                "200 OK", [("Content-Type", content_type)], protocol="HTTP/1.0"
+            )
+            record = writer.create_warc_record(
+                url,
+                "response",
+                payload=BytesIO(body),
+                length=len(body),
+                http_headers=http_headers,
+                warc_headers_dict={"WARC-Date": warc_date} if warc_date else None,
+            )
+            writer.write_record(record)
+        return buf.getvalue()
+
+    return _make
+
+
+@pytest.fixture(autouse=True)
+def _restore_std_streams():
+    """Guard against tests that swap ``sys.stdout`` / ``sys.stderr`` and fail
+    to restore them (e.g. the stdout-redirect context manager)."""
+    saved_out, saved_err = sys.stdout, sys.stderr
+    try:
+        yield
+    finally:
+        sys.stdout, sys.stderr = saved_out, saved_err

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -18,6 +18,8 @@ def test_period_lookup_by_value():
     """Period can be looked up by passing its string value to the constructor."""
     assert Period("DAY") is Period.DAY
     assert Period("FULL") is Period.FULL
+    assert Period("CUSTOM") is Period.CUSTOM
+    assert Period("WEEK") is Period.WEEK
 
 
 def test_defaults():

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,26 @@
+"""Tests for constants.py."""
+
+from constants import Period, DOWNLOAD_PERIOD, DOWNLOAD_RESET
+
+
+def test_period_members():
+    """Period enum defines exactly the four expected members."""
+    assert {p.name for p in Period} == {"DAY", "WEEK", "FULL", "CUSTOM"}
+
+
+def test_period_value_equals_name():
+    """Each Period member's value is the same string as its name."""
+    for p in Period:
+        assert p.value == p.name
+
+
+def test_period_lookup_by_value():
+    """Period can be looked up by passing its string value to the constructor."""
+    assert Period("DAY") is Period.DAY
+    assert Period("FULL") is Period.FULL
+
+
+def test_defaults():
+    """Module-level defaults are FULL period and reset disabled."""
+    assert DOWNLOAD_PERIOD is Period.FULL
+    assert DOWNLOAD_RESET is False

--- a/tests/test_internet_archive_downloader.py
+++ b/tests/test_internet_archive_downloader.py
@@ -1,0 +1,271 @@
+"""Tests for internet_archive_downloader.py.
+
+Network and pywaybackup interactions are stubbed out; these tests cover the
+pure logic (URL parsing, filename construction, date-range selection) and the
+filesystem/SQLite housekeeping helpers.
+"""
+
+import os
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+
+import internet_archive_downloader as d
+from constants import Period
+from wayback_date_object import WaybackDateObject
+
+
+# --------------------------------------------------------------------------- #
+# get_wayback_date_and_archived_url
+# --------------------------------------------------------------------------- #
+def test_parses_wayback_url():
+    """A Wayback Machine URL is split into a WaybackDateObject and the original archived URL."""
+    date, url = d.get_wayback_date_and_archived_url(
+        "https://web.archive.org/web/20030409193011/http://www.example.com/page"
+    )
+    assert isinstance(date, WaybackDateObject)
+    assert date.wayback_format() == "20030409193011"
+    assert url == "http://www.example.com/page"
+
+
+def test_non_wayback_url_returns_none_date():
+    """A plain URL (not a Wayback URL) returns None for the date and the URL unchanged."""
+    date, url = d.get_wayback_date_and_archived_url("http://www.example.com/live")
+    assert date is None
+    assert url == "http://www.example.com/live"
+
+
+# --------------------------------------------------------------------------- #
+# create_waybackup_filename
+# --------------------------------------------------------------------------- #
+def test_create_waybackup_filename_basic():
+    """A simple URL is converted to the expected 'waybackup_<sanitized>.csv' filename."""
+    assert (
+        d.create_waybackup_filename("http://www.example.com/page")
+        == "waybackup_http.www.example.com.page.csv"
+    )
+
+
+def test_create_waybackup_filename_collapses_repeated_punctuation():
+    """Special characters in query strings are sanitized without leaving consecutive dots."""
+    name = d.create_waybackup_filename("http://www.example.com/page?x=1")
+    assert name.startswith("waybackup_")
+    assert name.endswith(".csv")
+    assert ".." not in name
+
+
+# --------------------------------------------------------------------------- #
+# cleanup_temporary_files
+# --------------------------------------------------------------------------- #
+def test_cleanup_temporary_files_removes_contents(tmp_path):
+    """cleanup_temporary_files deletes all files and subdirectories but keeps the folder itself."""
+    snap = tmp_path / "snap"
+    snap.mkdir()
+    (snap / "file.txt").write_text("x")
+    subdir = snap / "sub"
+    subdir.mkdir()
+    (subdir / "nested.txt").write_text("y")
+
+    d.cleanup_temporary_files(str(snap))
+
+    assert snap.exists()  # the folder itself is kept
+    assert list(snap.iterdir()) == []
+
+
+def test_cleanup_temporary_files_missing_dir_is_noop(tmp_path):
+    """cleanup_temporary_files does not raise when the target directory does not exist."""
+    d.cleanup_temporary_files(str(tmp_path / "does-not-exist"))
+
+
+# --------------------------------------------------------------------------- #
+# copy_log_files
+# --------------------------------------------------------------------------- #
+def test_copy_log_files_copies_logs(tmp_path):
+    """copy_log_files copies .log files to the destination and ignores other file types."""
+    src = tmp_path / "snap"
+    src.mkdir()
+    (src / "a.log").write_text("log a")
+    (src / "ignore.txt").write_text("nope")
+    dest = tmp_path / "logs"
+
+    d.copy_log_files(str(src), str(dest))
+
+    assert (dest / "a.log").read_text() == "log a"
+    assert not (dest / "ignore.txt").exists()
+
+
+def test_copy_log_files_renames_on_conflict(tmp_path):
+    """copy_log_files appends a timestamp to the filename when the destination file already exists."""
+    src = tmp_path / "snap"
+    src.mkdir()
+    (src / "a.log").write_text("new")
+    dest = tmp_path / "logs"
+    dest.mkdir()
+    (dest / "a.log").write_text("existing")
+
+    d.copy_log_files(str(src), str(dest))
+
+    # Original is preserved and a timestamped copy is added.
+    assert (dest / "a.log").read_text() == "existing"
+    log_files = list(dest.glob("a*.log"))
+    assert len(log_files) == 2
+
+
+def test_copy_log_files_missing_source_is_noop(tmp_path):
+    """copy_log_files returns silently and does not create the destination when the source is missing."""
+    d.copy_log_files(str(tmp_path / "nope"), str(tmp_path / "logs"))
+    assert not (tmp_path / "logs").exists()
+
+
+def test_copy_log_files_no_logs_does_not_error(tmp_path):
+    """copy_log_files creates the destination directory but writes nothing when there are no .log files."""
+    src = tmp_path / "snap"
+    src.mkdir()
+    (src / "data.txt").write_text("x")
+    dest = tmp_path / "logs"
+    d.copy_log_files(str(src), str(dest))
+    assert list(dest.glob("*.log")) == []
+
+
+# --------------------------------------------------------------------------- #
+# drop_snapshot_indexes
+# --------------------------------------------------------------------------- #
+def test_drop_snapshot_indexes_removes_indexes(tmp_path):
+    """drop_snapshot_indexes drops all indexes from every SQLite database in the folder."""
+    db_path = tmp_path / "snapshot.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        conn.execute(text("CREATE TABLE t (id INTEGER, name TEXT)"))
+        conn.execute(text("CREATE INDEX idx_name ON t (name)"))
+        conn.commit()
+    engine.dispose()
+
+    d.drop_snapshot_indexes(str(tmp_path))
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    indexes = inspect(engine).get_indexes("t")
+    engine.dispose()
+    assert indexes == []
+
+
+def test_drop_snapshot_indexes_missing_dir_is_noop(tmp_path):
+    """drop_snapshot_indexes returns silently when the folder does not exist."""
+    d.drop_snapshot_indexes(str(tmp_path / "nope"))
+
+
+def test_drop_snapshot_indexes_no_db_files_is_noop(tmp_path):
+    """drop_snapshot_indexes returns silently when the folder contains no .db files."""
+    (tmp_path / "not_a_db.txt").write_text("x")
+    d.drop_snapshot_indexes(str(tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+# create_outlinks_warc
+# --------------------------------------------------------------------------- #
+def test_create_outlinks_warc_no_source_warcs_skips(tmp_path, monkeypatch):
+    """create_outlinks_warc does not call fetch_and_archive_outlinks when no WARC files are found."""
+    called = []
+    monkeypatch.setattr(d, "fetch_and_archive_outlinks", lambda *a, **k: called.append(a))
+    d.create_outlinks_warc(str(tmp_path), "site")
+    assert called == []
+
+
+def test_create_outlinks_warc_invokes_fetch(tmp_path, monkeypatch):
+    """create_outlinks_warc passes all matching WARC part files to fetch_and_archive_outlinks."""
+    (tmp_path / "site-0001.warc.gz").write_bytes(b"")
+    (tmp_path / "site-0002.warc.gz").write_bytes(b"")
+    captured = {}
+
+    def fake_fetch(source_warcs, warc_output, warcfile_name):
+        captured["sources"] = source_warcs
+        captured["name"] = warcfile_name
+
+    monkeypatch.setattr(d, "fetch_and_archive_outlinks", fake_fetch)
+    d.create_outlinks_warc(str(tmp_path), "site")
+
+    assert len(captured["sources"]) == 2
+    assert captured["name"] == "site"
+
+
+# --------------------------------------------------------------------------- #
+# download_urls_from_csv (date-range selection, network stubbed)
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def _stub_downloader(monkeypatch):
+    """Stub out the side-effecting pieces of download_urls_from_csv and record
+    the (start, end) date range passed to download_single_url."""
+    calls = {}
+
+    def fake_download_single_url(url, start, end, *a, **k):
+        calls["url"] = url
+        calls["start"] = start
+        calls["end"] = end
+
+    monkeypatch.setattr(d, "download_single_url", fake_download_single_url)
+    monkeypatch.setattr(d, "process_csv_file", lambda *a, **k: None)
+    monkeypatch.setattr(d, "create_outlinks_warc", lambda *a, **k: None)
+    monkeypatch.setattr(d, "drop_snapshot_indexes", lambda *a, **k: None)
+    monkeypatch.setattr(d, "copy_log_files", lambda *a, **k: None)
+    return calls
+
+
+def _write_url_csv(tmp_path, url):
+    csv = tmp_path / "urls.csv"
+    # utils.read_csv uses ';' as the separator.
+    csv.write_text(f"Internet_Archive_URL\n{url}\n")
+    return str(csv)
+
+
+def test_download_day_period_range(tmp_path, _stub_downloader):
+    """Period.DAY sets the download window to one day before and after the archived date."""
+    csv = _write_url_csv(
+        tmp_path, "https://web.archive.org/web/20030409193011/http://a.com"
+    )
+    d.download_urls_from_csv(csv, "Internet_Archive_URL", download_period=Period.DAY)
+    assert _stub_downloader["start"] == "20030408193011"
+    assert _stub_downloader["end"] == "20030410193011"
+
+
+def test_download_week_period_range(tmp_path, _stub_downloader):
+    """Period.WEEK sets the download window to one week before and after the archived date."""
+    csv = _write_url_csv(
+        tmp_path, "https://web.archive.org/web/20030409193011/http://a.com"
+    )
+    d.download_urls_from_csv(csv, "Internet_Archive_URL", download_period=Period.WEEK)
+    assert _stub_downloader["start"] == "20030402193011"
+    assert _stub_downloader["end"] == "20030416193011"
+
+
+def test_download_full_period_uses_fixed_range(tmp_path, _stub_downloader):
+    """Period.FULL uses the fixed range 1995-01-01 to 2005-12-31 regardless of the archived date."""
+    csv = _write_url_csv(
+        tmp_path, "https://web.archive.org/web/20030409193011/http://a.com"
+    )
+    d.download_urls_from_csv(csv, "Internet_Archive_URL", download_period=Period.FULL)
+    assert _stub_downloader["start"] == "19950101000000"
+    assert _stub_downloader["end"] == "20051231235959"
+
+
+def test_download_defaults_to_full_when_period_none(tmp_path, _stub_downloader):
+    """Passing download_period=None defaults to the FULL period range."""
+    csv = _write_url_csv(
+        tmp_path, "https://web.archive.org/web/20030409193011/http://a.com"
+    )
+    d.download_urls_from_csv(csv, "Internet_Archive_URL", download_period=None)
+    assert _stub_downloader["start"] == "19950101000000"
+
+
+def test_download_custom_period_uses_start_end(tmp_path, _stub_downloader):
+    """Period.CUSTOM passes the caller-supplied start_time and end_time directly to the downloader."""
+    csv = _write_url_csv(
+        tmp_path, "https://web.archive.org/web/20030409193011/http://a.com"
+    )
+    d.download_urls_from_csv(
+        csv,
+        "Internet_Archive_URL",
+        start_time="20000101000000",
+        end_time="20001231235959",
+        download_period=Period.CUSTOM,
+    )
+    assert _stub_downloader["start"] == "20000101000000"
+    assert _stub_downloader["end"] == "20001231235959"

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,138 @@
+"""Tests for logging_config.py."""
+
+import logging
+import sys
+
+import pytest
+
+from logging_config import (
+    LoggerWriter,
+    get_logger,
+    redirect_stdout_to_logger,
+    setup_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_root_logger():
+    """Restore the root logger configuration after each test."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    try:
+        yield
+    finally:
+        root.handlers = saved_handlers
+        root.setLevel(saved_level)
+
+
+def test_setup_logging_sets_level_and_console_handler():
+    """setup_logging configures the root logger with the given level and one console handler."""
+    logger = setup_logging(log_level=logging.DEBUG)
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) == 1
+    assert isinstance(logger.handlers[0], logging.StreamHandler)
+
+
+def test_setup_logging_replaces_existing_handlers():
+    """Calling setup_logging twice does not accumulate handlers; the second call replaces the first."""
+    setup_logging(log_level=logging.INFO)
+    setup_logging(log_level=logging.WARNING)
+    assert len(logging.getLogger().handlers) == 1
+
+
+def test_setup_logging_adds_file_handler_and_creates_parent(tmp_path):
+    """setup_logging creates missing parent directories and adds a FileHandler when log_file is given."""
+    log_file = tmp_path / "nested" / "app.log"
+    logger = setup_logging(log_level=logging.INFO, log_file=str(log_file))
+    assert log_file.parent.is_dir()
+    assert any(isinstance(h, logging.FileHandler) for h in logger.handlers)
+    # Ensure the file handler is released so tmp_path cleanup works on all OSes.
+    for h in logger.handlers:
+        h.close()
+
+
+def test_get_logger_returns_named_logger():
+    """get_logger returns a logger whose name matches the argument."""
+    assert get_logger("foo.bar").name == "foo.bar"
+
+
+def test_logger_writer_logs_non_blank_messages():
+    """LoggerWriter forwards non-blank messages to the logger and discards whitespace-only writes."""
+    records = []
+    logger = logging.getLogger("test.writer")
+    logger.handlers = [_CapturingHandler(records)]
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
+    writer = LoggerWriter(logger, logging.INFO)
+    writer.write("hello\n")
+    writer.write("   ")  # whitespace-only -> ignored
+    writer.write("")  # empty -> ignored
+
+    assert [r.getMessage() for r in records] == ["hello"]
+    assert records[0].levelno == logging.INFO
+
+
+def test_logger_writer_flush_is_noop():
+    """LoggerWriter.flush() returns None without raising."""
+    writer = LoggerWriter(logging.getLogger("x"), logging.INFO)
+    assert writer.flush() is None
+
+
+def test_redirect_stdout_to_logger_captures_and_restores():
+    """redirect_stdout_to_logger routes stdout to INFO and stderr to ERROR, then restores both streams."""
+    records = []
+    logger = logging.getLogger("test.redirect")
+    logger.handlers = [_CapturingHandler(records)]
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
+    original_stdout, original_stderr = sys.stdout, sys.stderr
+    with redirect_stdout_to_logger(logger):
+        print("to stdout")
+        print("to stderr", file=sys.stderr)
+
+    # Streams restored afterwards.
+    assert sys.stdout is original_stdout
+    assert sys.stderr is original_stderr
+
+    messages = {(r.getMessage(), r.levelno) for r in records}
+    assert ("to stdout", logging.INFO) in messages
+    assert ("to stderr", logging.ERROR) in messages
+
+
+def test_redirect_stdout_to_logger_custom_levels():
+    """redirect_stdout_to_logger respects a custom stderr_level argument."""
+    records = []
+    logger = logging.getLogger("test.redirect.levels")
+    logger.handlers = [_CapturingHandler(records)]
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
+    with redirect_stdout_to_logger(logger, stderr_level=logging.INFO):
+        print("err as info", file=sys.stderr)
+
+    assert records[0].levelno == logging.INFO
+
+
+def test_redirect_restores_streams_on_exception():
+    """redirect_stdout_to_logger restores sys.stdout even when the body raises an exception."""
+    logger = logging.getLogger("test.redirect.exc")
+    logger.handlers = [_CapturingHandler([])]
+    logger.propagate = False
+
+    original_stdout = sys.stdout
+    with pytest.raises(RuntimeError):
+        with redirect_stdout_to_logger(logger):
+            raise RuntimeError("boom")
+    assert sys.stdout is original_stdout
+
+
+class _CapturingHandler(logging.Handler):
+    def __init__(self, sink):
+        super().__init__()
+        self.sink = sink
+
+    def emit(self, record):
+        self.sink.append(record)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,90 @@
+"""Tests for utils.py."""
+
+import pandas as pd
+import pytest
+
+import utils
+from utils import (
+    clean_urls,
+    import_urls_from_csv,
+    read_csv,
+    remove_port_80,
+)
+
+
+def test_remove_port_80_strips_port():
+    """Port :80 is removed from a URL that contains it."""
+    assert remove_port_80("http://example.com:80/page") == "http://example.com/page"
+
+
+def test_remove_port_80_leaves_other_urls_untouched():
+    """URLs without :80 are returned unchanged."""
+    assert remove_port_80("http://example.com/page") == "http://example.com/page"
+
+
+def test_remove_port_80_naive_substring_match_mangles_other_ports():
+    """Documents a known quirk: the check is a naive ':80' substring replace, so
+    a ':8080' port has its leading ':80' stripped, leaving a mangled URL."""
+    assert remove_port_80("http://example.com:8080/page") == "http://example.com80/page"
+
+
+def test_read_csv_uses_semicolon_separator(tmp_path):
+    """read_csv parses files with semicolons as the column delimiter."""
+    csv = tmp_path / "data.csv"
+    csv.write_text("a;b\n1;2\n")
+    df = read_csv(str(csv))
+    assert list(df.columns) == ["a", "b"]
+    assert df.iloc[0]["a"] == 1
+
+
+def test_clean_urls_strips_port_from_both_columns():
+    """clean_urls removes :80 from both url_archive and url_origin columns."""
+    df = pd.DataFrame(
+        {
+            "url_archive": ["http://a.com:80/x", "http://b.com/y"],
+            "url_origin": ["http://c.com:80/z", "http://d.com/w"],
+        }
+    )
+    out = clean_urls(df)
+    assert out["url_archive"].tolist() == ["http://a.com/x", "http://b.com/y"]
+    assert out["url_origin"].tolist() == ["http://c.com/z", "http://d.com/w"]
+
+
+def test_import_urls_from_csv_returns_column_values(tmp_path):
+    """import_urls_from_csv returns the values of the requested column as a list."""
+    csv = tmp_path / "urls.csv"
+    csv.write_text("Internet_Archive_URL;other\nhttp://a.com;1\nhttp://b.com;2\n")
+    urls = import_urls_from_csv(str(csv), "Internet_Archive_URL")
+    assert urls == ["http://a.com", "http://b.com"]
+
+
+def test_import_urls_from_csv_missing_column_raises(tmp_path):
+    """import_urls_from_csv raises KeyError when the column does not exist."""
+    csv = tmp_path / "urls.csv"
+    csv.write_text("a;b\n1;2\n")
+    with pytest.raises(KeyError):
+        import_urls_from_csv(str(csv), "does_not_exist")
+
+
+def test_import_urls_from_csv_missing_file_raises():
+    """import_urls_from_csv raises FileNotFoundError for a non-existent file."""
+    with pytest.raises(FileNotFoundError):
+        import_urls_from_csv("/no/such/file.csv", "Internet_Archive_URL")
+
+
+@pytest.mark.xfail(
+    reason="utils.create_warc_gz calls WARCWriter.write_webpage, which does not "
+    "exist in warcio; the function is currently broken/dead code.",
+    raises=AttributeError,
+    strict=True,
+)
+def test_create_warc_gz_is_currently_broken(tmp_path):
+    """create_warc_gz raises AttributeError because WARCWriter.write_webpage does not exist."""
+    df = pd.DataFrame(
+        {
+            "url_origin": ["http://a.com"],
+            "url_archive": ["http://web.archive.org/a"],
+            "timestamp": ["20030409193011"],
+        }
+    )
+    utils.create_warc_gz(str(tmp_path / "out.warc.gz"), df)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,19 +72,4 @@ def test_import_urls_from_csv_missing_file_raises():
         import_urls_from_csv("/no/such/file.csv", "Internet_Archive_URL")
 
 
-@pytest.mark.xfail(
-    reason="utils.create_warc_gz calls WARCWriter.write_webpage, which does not "
-    "exist in warcio; the function is currently broken/dead code.",
-    raises=AttributeError,
-    strict=True,
-)
-def test_create_warc_gz_is_currently_broken(tmp_path):
-    """create_warc_gz raises AttributeError because WARCWriter.write_webpage does not exist."""
-    df = pd.DataFrame(
-        {
-            "url_origin": ["http://a.com"],
-            "url_archive": ["http://web.archive.org/a"],
-            "timestamp": ["20030409193011"],
-        }
-    )
-    utils.create_warc_gz(str(tmp_path / "out.warc.gz"), df)
+

--- a/tests/test_warc_outlinks.py
+++ b/tests/test_warc_outlinks.py
@@ -221,11 +221,11 @@ def test_download_resource_retries_on_429():
     assert resp.status_code == 200
 
 
-def test_download_resource_returns_last_response_after_exhausting_retries():
-    """When all retry attempts return server errors, the last response is returned."""
+def test_download_resource_returns_none_after_exhausting_retries():
+    """When all retry attempts return server errors, the resource is treated as a failure (None)."""
     session = _FakeSession([_Resp(status_code=500), _Resp(status_code=503)])
     resp = o._download_archived_resource("http://a.com", "2000", session, "UA", 30, 1)
-    assert resp.status_code == 503
+    assert resp is None
     assert session.calls == 2
 
 

--- a/tests/test_warc_outlinks.py
+++ b/tests/test_warc_outlinks.py
@@ -1,0 +1,348 @@
+"""Tests for warc_outlinks.py (outgoing-link archiving)."""
+
+from io import BytesIO
+
+import pytest
+import requests
+from warcio.archiveiterator import ArchiveIterator
+
+import warc_outlinks as o
+
+
+# --------------------------------------------------------------------------- #
+# extract_outgoing_links
+# --------------------------------------------------------------------------- #
+def test_extract_resolves_relative_links():
+    """Relative href values are resolved to absolute URLs using the page's base URL."""
+    html = b'<a href="page2.html">x</a>'
+    links = o.extract_outgoing_links(html, "http://a.com/dir/page1.html")
+    assert links == ["http://a.com/dir/page2.html"]
+
+
+def test_extract_collects_embedded_resources():
+    """img, script, link, and iframe tags are all collected alongside anchor hrefs."""
+    html = (
+        b'<img src="img.png">'
+        b'<script src="app.js"></script>'
+        b'<link href="style.css">'
+        b'<iframe src="frame.html"></iframe>'
+    )
+    links = o.extract_outgoing_links(html, "http://a.com/")
+    assert set(links) == {
+        "http://a.com/img.png",
+        "http://a.com/app.js",
+        "http://a.com/style.css",
+        "http://a.com/frame.html",
+    }
+
+
+def test_extract_video_has_two_url_attrs():
+    """Video tags yield both the src and poster attributes as separate links."""
+    html = b'<video src="v.mp4" poster="p.jpg"></video>'
+    links = o.extract_outgoing_links(html, "http://a.com/")
+    assert set(links) == {"http://a.com/v.mp4", "http://a.com/p.jpg"}
+
+
+def test_extract_deduplicates_preserving_order():
+    """Duplicate URLs appear only once, with the first occurrence's position preserved."""
+    html = b'<a href="b.html">1</a><a href="c.html">2</a><a href="b.html">3</a>'
+    links = o.extract_outgoing_links(html, "http://a.com/")
+    assert links == ["http://a.com/b.html", "http://a.com/c.html"]
+
+
+def test_extract_skips_fragment_and_nonfetchable_schemes():
+    """Fragment-only links and non-HTTP schemes (mailto, javascript, tel, ftp) are discarded."""
+    html = (
+        b'<a href="#top">x</a>'
+        b'<a href="mailto:me@a.com">x</a>'
+        b'<a href="javascript:void(0)">x</a>'
+        b'<a href="tel:123">x</a>'
+        b'<a href="ftp://a.com/f">x</a>'
+        b'<a href="http://a.com/keep">x</a>'
+    )
+    links = o.extract_outgoing_links(html, "http://a.com/")
+    assert links == ["http://a.com/keep"]
+
+
+def test_extract_strips_fragment_from_otherwise_valid_link():
+    """Fragment identifiers are stripped from otherwise valid HTTP links."""
+    html = b'<a href="http://a.com/page#section">x</a>'
+    assert o.extract_outgoing_links(html, "http://a.com/") == ["http://a.com/page"]
+
+
+def test_extract_ignores_empty_href():
+    """Anchor tags with empty or missing href attributes produce no links."""
+    html = b'<a href="">x</a><a>y</a>'
+    assert o.extract_outgoing_links(html, "http://a.com/") == []
+
+
+# --------------------------------------------------------------------------- #
+# timestamp conversion helpers
+# --------------------------------------------------------------------------- #
+def test_warc_date_to_timestamp_roundtrip():
+    """A Wayback timestamp converts to a WARC-Date string and back without loss."""
+    ts = "20000302202605"
+    warc_date = o._timestamp_to_warc_date(ts)
+    assert warc_date == "2000-03-02T20:26:05Z"
+    assert o._warc_date_to_timestamp(warc_date) == ts
+
+
+@pytest.mark.parametrize("bad", [None, "", "garbage", "2000-03-02"])
+def test_warc_date_to_timestamp_invalid_returns_none(bad):
+    """_warc_date_to_timestamp returns None for any value that is not a valid WARC-Date."""
+    assert o._warc_date_to_timestamp(bad) is None
+
+
+@pytest.mark.parametrize("bad", [None, "", "garbage", "2000"])
+def test_timestamp_to_warc_date_invalid_returns_none(bad):
+    """_timestamp_to_warc_date returns None for any value that is not a 14-digit Wayback timestamp."""
+    assert o._timestamp_to_warc_date(bad) is None
+
+
+# --------------------------------------------------------------------------- #
+# _actual_capture_timestamp
+# --------------------------------------------------------------------------- #
+class _Resp:
+    def __init__(self, url="", status_code=200, reason="OK", headers=None, content=b""):
+        self.url = url
+        self.status_code = status_code
+        self.reason = reason
+        self.headers = headers or {}
+        self.content = content
+
+
+def test_actual_capture_timestamp_prefers_redirected_url():
+    """The timestamp embedded in the final redirected URL takes priority over the requested one."""
+    resp = _Resp(url="https://web.archive.org/web/19991231120000id_/http://a.com")
+    assert o._actual_capture_timestamp(resp, "20000101000000") == "19991231120000"
+
+
+def test_actual_capture_timestamp_falls_back_to_requested():
+    """When no timestamp is found in the response URL, the originally requested one is returned."""
+    resp = _Resp(url="https://example.com/no-timestamp")
+    assert o._actual_capture_timestamp(resp, "20000101000000") == "20000101000000"
+
+
+# --------------------------------------------------------------------------- #
+# collect_outlinks_from_warcs
+# --------------------------------------------------------------------------- #
+def test_collect_outlinks_from_warcs(tmp_path, warc_bytes_factory):
+    """Outgoing links are extracted from HTML records; self-links already in the WARC are excluded."""
+    warc_bytes = warc_bytes_factory(
+        [
+            (
+                "http://a.com/index.html",
+                "2000-03-02T20:26:05Z",
+                "text/html",
+                b'<a href="http://a.com/out.html">x</a><a href="http://a.com/index.html">self</a>',
+            )
+        ]
+    )
+    warc_path = tmp_path / "src-0001.warc.gz"
+    warc_path.write_bytes(warc_bytes)
+
+    outlinks = o.collect_outlinks_from_warcs([str(warc_path)])
+    # The self-link (already captured) is excluded; the outgoing link keeps the page date.
+    assert outlinks == {"http://a.com/out.html": "20000302202605"}
+
+
+def test_collect_outlinks_skips_non_html(tmp_path, warc_bytes_factory):
+    """Non-HTML WARC records (e.g. images) are not scanned for outgoing links."""
+    warc_bytes = warc_bytes_factory(
+        [("http://a.com/pic.png", "2000-03-02T20:26:05Z", "image/png", b"\x89PNG")]
+    )
+    warc_path = tmp_path / "src-0001.warc.gz"
+    warc_path.write_bytes(warc_bytes)
+    assert o.collect_outlinks_from_warcs([str(warc_path)]) == {}
+
+
+def test_collect_outlinks_keeps_earliest_timestamp(tmp_path, warc_bytes_factory):
+    """When a link appears on multiple pages, the earliest capture timestamp is kept."""
+    warc_bytes = warc_bytes_factory(
+        [
+            ("http://a.com/p1.html", "2000-01-01T00:00:00Z", "text/html",
+             b'<a href="http://a.com/shared.html">x</a>'),
+            ("http://a.com/p2.html", "2001-01-01T00:00:00Z", "text/html",
+             b'<a href="http://a.com/shared.html">x</a>'),
+        ]
+    )
+    warc_path = tmp_path / "src-0001.warc.gz"
+    warc_path.write_bytes(warc_bytes)
+    outlinks = o.collect_outlinks_from_warcs([str(warc_path)])
+    assert outlinks["http://a.com/shared.html"] == "20000101000000"
+
+
+# --------------------------------------------------------------------------- #
+# _download_archived_resource (mocked session)
+# --------------------------------------------------------------------------- #
+class _FakeSession:
+    def __init__(self, responses):
+        # responses: list of _Resp or Exception instances, consumed per call.
+        self._responses = list(responses)
+        self.calls = 0
+
+    def get(self, url, **kwargs):
+        self.calls += 1
+        item = self._responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Make retry backoff instantaneous."""
+    monkeypatch.setattr(o.time, "sleep", lambda *_: None)
+
+
+def test_download_resource_success_first_try():
+    """A 200 response on the first attempt is returned immediately with no retries."""
+    session = _FakeSession([_Resp(status_code=200)])
+    resp = o._download_archived_resource("http://a.com", "2000", session, "UA", 30, 2)
+    assert resp.status_code == 200
+    assert session.calls == 1
+
+
+def test_download_resource_retries_on_500_then_succeeds():
+    """A 500 response triggers a retry, and the subsequent 200 is returned."""
+    session = _FakeSession([_Resp(status_code=500), _Resp(status_code=200)])
+    resp = o._download_archived_resource("http://a.com", "2000", session, "UA", 30, 2)
+    assert resp.status_code == 200
+    assert session.calls == 2
+
+
+def test_download_resource_retries_on_429():
+    """A 429 rate-limit response is retried and the next 200 is returned."""
+    session = _FakeSession([_Resp(status_code=429), _Resp(status_code=200)])
+    resp = o._download_archived_resource("http://a.com", "2000", session, "UA", 30, 2)
+    assert resp.status_code == 200
+
+
+def test_download_resource_returns_last_response_after_exhausting_retries():
+    """When all retry attempts return server errors, the last response is returned."""
+    session = _FakeSession([_Resp(status_code=500), _Resp(status_code=503)])
+    resp = o._download_archived_resource("http://a.com", "2000", session, "UA", 30, 1)
+    assert resp.status_code == 503
+    assert session.calls == 2
+
+
+def test_download_resource_returns_none_on_persistent_exception():
+    """None is returned when every attempt raises a network-level RequestException."""
+    session = _FakeSession([requests.RequestException("x"), requests.RequestException("y")])
+    resp = o._download_archived_resource("http://a.com", "2000", session, "UA", 30, 1)
+    assert resp is None
+
+
+def test_download_resource_does_not_retry_on_404():
+    """A 404 response is treated as a definitive answer and returned without retrying."""
+    session = _FakeSession([_Resp(status_code=404)])
+    resp = o._download_archived_resource("http://a.com", "2000", session, "UA", 30, 2)
+    assert resp.status_code == 404
+    assert session.calls == 1
+
+
+# --------------------------------------------------------------------------- #
+# _OutlinksWarcWriter
+# --------------------------------------------------------------------------- #
+def _read_outlink_records(path):
+    out = []
+    with open(path, "rb") as stream:
+        for record in ArchiveIterator(stream):
+            out.append(
+                (
+                    record.rec_headers.get_header("WARC-Target-URI"),
+                    record.http_headers.get_statuscode(),
+                    record.content_stream().read(),
+                )
+            )
+    return out
+
+
+def test_outlinks_writer_writes_record(tmp_path):
+    """_OutlinksWarcWriter writes a WARC record with the correct URL, status, and payload."""
+    writer = o._OutlinksWarcWriter(str(tmp_path), "site_outlinks", 1073741824)
+    writer.write_resource(
+        url="http://a.com/x",
+        status_code=200,
+        reason="OK",
+        content_type="text/html",
+        content=b"<html></html>",
+        warc_date="2000-03-02T20:26:05Z",
+    )
+    writer.close()
+
+    records = _read_outlink_records(str(tmp_path / "site_outlinks-0001.warc.gz"))
+    assert records[0][0] == "http://a.com/x"
+    assert records[0][1] == "200"
+    assert records[0][2] == b"<html></html>"
+
+
+def test_outlinks_writer_splits_on_size(tmp_path):
+    """_OutlinksWarcWriter opens a new part file when the size threshold is exceeded."""
+    writer = o._OutlinksWarcWriter(str(tmp_path), "site_outlinks", max_size_bytes=10)
+    for i in range(3):
+        writer.write_resource(
+            url=f"http://a.com/{i}",
+            status_code=200,
+            reason="OK",
+            content_type="text/html",
+            content=b"x" * 20,
+            warc_date=None,
+        )
+    writer.close()
+    parts = sorted(tmp_path.glob("site_outlinks-*.warc.gz"))
+    assert len(parts) >= 2
+
+
+# --------------------------------------------------------------------------- #
+# fetch_and_archive_outlinks (end-to-end with mocked network)
+# --------------------------------------------------------------------------- #
+def test_fetch_and_archive_outlinks_no_links_writes_nothing(tmp_path, monkeypatch):
+    """fetch_and_archive_outlinks exits early and writes no files when there are no outlinks."""
+    monkeypatch.setattr(o, "collect_outlinks_from_warcs", lambda paths: {})
+    o.fetch_and_archive_outlinks(["unused"], str(tmp_path), "site")
+    assert list(tmp_path.glob("*.warc.gz")) == []
+
+
+def test_fetch_and_archive_outlinks_end_to_end(tmp_path, monkeypatch):
+    """fetch_and_archive_outlinks downloads each outlink and stores it in a WARC file."""
+    monkeypatch.setattr(
+        o, "collect_outlinks_from_warcs",
+        lambda paths: {"http://a.com/out.html": "20000302202605"},
+    )
+
+    captured = _Resp(
+        url="https://web.archive.org/web/20000302202605id_/http://a.com/out.html",
+        status_code=200,
+        reason="OK",
+        headers={"Content-Type": "text/html"},
+        content=b"<html>linked</html>",
+    )
+    monkeypatch.setattr(requests, "Session", lambda: _FakeSession([captured]))
+
+    o.fetch_and_archive_outlinks(["unused"], str(tmp_path), "site", delay=0)
+
+    records = _read_outlink_records(str(tmp_path / "site_outlinks-0001.warc.gz"))
+    assert records[0][0] == "http://a.com/out.html"
+    assert records[0][2] == b"<html>linked</html>"
+
+
+def test_fetch_and_archive_outlinks_counts_failures(tmp_path, monkeypatch):
+    """Failed downloads are counted and omitted from the WARC; the part file is still created."""
+    monkeypatch.setattr(
+        o, "collect_outlinks_from_warcs",
+        lambda paths: {"http://a.com/out.html": "20000302202605"},
+    )
+    # Session always raises -> download returns None -> counted as failure, no record.
+    monkeypatch.setattr(
+        requests, "Session",
+        lambda: _FakeSession([requests.RequestException("x"), requests.RequestException("y"),
+                              requests.RequestException("z")]),
+    )
+    o.fetch_and_archive_outlinks(["unused"], str(tmp_path), "site", delay=0, max_retries=2)
+    # An (empty) WARC part file is still created.
+    records = _read_outlink_records(str(tmp_path / "site_outlinks-0001.warc.gz"))
+    assert records == []

--- a/tests/test_wayback_date_object.py
+++ b/tests/test_wayback_date_object.py
@@ -1,0 +1,118 @@
+"""Tests for the WaybackDateObject date helper."""
+
+from datetime import datetime
+
+import pytest
+
+from wayback_date_object import WaybackDateObject
+
+
+def test_parses_components_from_string():
+    """Constructor splits a 14-digit Wayback string into year/month/day/hour/minute/second."""
+    obj = WaybackDateObject("20030409193011")
+    assert obj.year == "2003"
+    assert obj.month == "04"
+    assert obj.day == "09"
+    assert obj.hour == "19"
+    assert obj.minute == "30"
+    assert obj.second == "11"
+
+
+def test_pretty_print():
+    """pretty_print returns a human-readable 'YYYY-MM-DD HH:MM:SS' string."""
+    obj = WaybackDateObject("20030409193011")
+    assert obj.pretty_print() == "2003-04-09 19:30:11"
+
+
+def test_wayback_format_roundtrips_input():
+    """wayback_format reconstructs the original 14-digit string."""
+    raw = "20030409193011"
+    assert WaybackDateObject(raw).wayback_format() == raw
+
+
+def test_to_datetime():
+    """to_datetime converts the stored values to an equivalent Python datetime."""
+    obj = WaybackDateObject("20030409193011")
+    assert obj.to_datetime() == datetime(2003, 4, 9, 19, 30, 11)
+
+
+def test_from_datetime_zero_pads():
+    """from_datetime zero-pads each field so wayback_format stays 14 digits wide."""
+    obj = WaybackDateObject("20030409193011")
+    obj.from_datetime(datetime(5, 1, 2, 3, 4, 5))
+    assert obj.year == "0005"
+    assert obj.month == "01"
+    assert obj.wayback_format() == "00050102030405"
+
+
+def test_increment_day_simple():
+    """increment_day advances the date by one day within the same month."""
+    obj = WaybackDateObject("20030409193011")
+    obj.increment_day()
+    assert obj.wayback_format() == "20030410193011"
+
+
+def test_decrement_day_simple():
+    """decrement_day moves the date back by one day within the same month."""
+    obj = WaybackDateObject("20030409193011")
+    obj.decrement_day()
+    assert obj.wayback_format() == "20030408193011"
+
+
+def test_increment_day_crosses_month_boundary():
+    """increment_day rolls over to the next month correctly."""
+    obj = WaybackDateObject("20030430120000")
+    obj.increment_day()
+    assert obj.wayback_format() == "20030501120000"
+
+
+def test_decrement_day_crosses_month_boundary():
+    """decrement_day rolls back into the previous month with the correct number of days."""
+    obj = WaybackDateObject("20030301120000")
+    obj.decrement_day()
+    # 2003 is not a leap year, so February has 28 days.
+    assert obj.wayback_format() == "20030228120000"
+
+
+def test_increment_day_leap_year():
+    """increment_day produces Feb 29 when the year is a leap year."""
+    obj = WaybackDateObject("20000228120000")
+    obj.increment_day()
+    # 2000 is a leap year, so Feb 29 exists.
+    assert obj.wayback_format() == "20000229120000"
+
+
+def test_increment_day_crosses_year_boundary():
+    """increment_day rolls Dec 31 over to Jan 1 of the next year."""
+    obj = WaybackDateObject("20031231235900")
+    obj.increment_day()
+    assert obj.wayback_format() == "20040101235900"
+
+
+def test_increment_week():
+    """increment_week advances the date by exactly 7 days."""
+    obj = WaybackDateObject("20030409193011")
+    obj.increment_week()
+    assert obj.wayback_format() == "20030416193011"
+
+
+def test_decrement_week_crosses_month():
+    """decrement_week moves the date back 7 days, crossing a month boundary."""
+    obj = WaybackDateObject("20030405120000")
+    obj.decrement_week()
+    assert obj.wayback_format() == "20030329120000"
+
+
+def test_increment_then_decrement_day_is_identity():
+    """Incrementing then decrementing by one day returns to the original date."""
+    obj = WaybackDateObject("20030409193011")
+    obj.increment_day()
+    obj.decrement_day()
+    assert obj.wayback_format() == "20030409193011"
+
+
+def test_invalid_month_raises_on_to_datetime():
+    """to_datetime raises ValueError when the stored values form an impossible date."""
+    obj = WaybackDateObject("20031340120000")  # month 13, day 40
+    with pytest.raises(ValueError):
+        obj.to_datetime()

--- a/tests/test_waybackup_to_warc.py
+++ b/tests/test_waybackup_to_warc.py
@@ -1,0 +1,236 @@
+"""Tests for waybackup_to_warc.py (CSV -> WARC conversion)."""
+
+import gzip
+import os
+
+import pandas as pd
+import pytest
+from warcio.archiveiterator import ArchiveIterator
+from warcio.warcwriter import WARCWriter
+
+import waybackup_to_warc as w
+
+
+def _read_records(warc_path):
+    """Return a list of (target_uri, status_line, payload_bytes) from a WARC."""
+    out = []
+    with open(warc_path, "rb") as stream:
+        for record in ArchiveIterator(stream):
+            if record.rec_type != "response":
+                continue
+            uri = record.rec_headers.get_header("WARC-Target-URI")
+            status = record.http_headers.get_statuscode() if record.http_headers else None
+            payload = record.content_stream().read()
+            out.append((uri, status, payload))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# remove_port_80 / process_csv
+# --------------------------------------------------------------------------- #
+def test_remove_port_80():
+    """remove_port_80 strips :80 and leaves URLs without it unchanged."""
+    assert w.remove_port_80("http://a.com:80/x") == "http://a.com/x"
+    assert w.remove_port_80("http://a.com/x") == "http://a.com/x"
+
+
+def test_process_csv_strips_ports(tmp_path):
+    """process_csv removes :80 from both url_archive and url_origin columns."""
+    csv = tmp_path / "in.csv"
+    csv.write_text(
+        "url_archive,url_origin\n"
+        "http://web.archive.org:80/a,http://a.com:80/x\n"
+    )
+    df = w.process_csv(str(csv))
+    assert df.iloc[0]["url_archive"] == "http://web.archive.org/a"
+    assert df.iloc[0]["url_origin"] == "http://a.com/x"
+
+
+# --------------------------------------------------------------------------- #
+# write_404 / write_500 helpers
+# --------------------------------------------------------------------------- #
+def test_write_404_warc_entry(tmp_path):
+    """write_404_warc_entry writes a WARC response record with a 404 status."""
+    path = tmp_path / "out.warc.gz"
+    with open(path, "wb") as stream:
+        writer = WARCWriter(stream, gzip=True)
+        w.write_404_warc_entry(writer, "http://a.com", "2003-04-09T19:30:11Z")
+
+    records = _read_records(str(path))
+    assert len(records) == 1
+    uri, status, _ = records[0]
+    assert uri == "http://a.com"
+    assert status == "404"
+
+
+def test_write_500_warc_entry(tmp_path):
+    """write_500_warc_entry writes a WARC response record with a 500 status."""
+    path = tmp_path / "out.warc.gz"
+    with open(path, "wb") as stream:
+        writer = WARCWriter(stream, gzip=True)
+        w.write_500_warc_entry(writer, "http://a.com", "2003-04-09T19:30:11Z")
+
+    uri, status, _ = _read_records(str(path))[0]
+    assert status == "500"
+
+
+# --------------------------------------------------------------------------- #
+# create_warc_gz
+# --------------------------------------------------------------------------- #
+def test_create_warc_gz_empty_data_creates_nothing(tmp_path):
+    """create_warc_gz with an empty data list writes no files and returns silently."""
+    w.create_warc_gz([], str(tmp_path), "out")
+    assert list(tmp_path.glob("*.warc.gz")) == []
+
+
+def test_create_warc_gz_writes_200_record_with_content(tmp_path):
+    """create_warc_gz writes a 200 WARC record whose payload matches the source file."""
+    src = tmp_path / "page.html"
+    src.write_bytes(b"<html>hi</html>")
+    data = [
+        {
+            "url_origin": "http://a.com",
+            "file": str(src),
+            "timestamp": "20030409193011",
+            "response": "200",
+        }
+    ]
+    w.create_warc_gz(data, str(tmp_path / "out"), "site")
+
+    warcs = sorted((tmp_path / "out").glob("site-*.warc.gz"))
+    assert len(warcs) == 1
+    records = _read_records(str(warcs[0]))
+    assert records[0][0] == "http://a.com"
+    assert records[0][1] == "200"
+    assert records[0][2] == b"<html>hi</html>"
+
+
+def test_create_warc_gz_404_and_500_records(tmp_path):
+    """create_warc_gz writes dedicated error records for 404 and 500 response codes."""
+    data = [
+        {"url_origin": "http://a.com/404", "file": "missing", "timestamp": "20030409193011", "response": "404"},
+        {"url_origin": "http://a.com/500", "file": "missing", "timestamp": "20030409193011", "response": "500"},
+    ]
+    out = tmp_path / "out"
+    w.create_warc_gz(data, str(out), "site")
+    statuses = sorted(s for _, s, _ in _read_records(str(next(out.glob("site-*.warc.gz")))))
+    assert statuses == ["404", "500"]
+
+
+def test_create_warc_gz_skips_missing_200_file(tmp_path):
+    """create_warc_gz silently skips a 200 entry whose local file does not exist."""
+    data = [
+        {"url_origin": "http://a.com", "file": str(tmp_path / "nope.html"), "timestamp": "20030409193011", "response": "200"},
+    ]
+    out = tmp_path / "out"
+    w.create_warc_gz(data, str(out), "site")
+    # The WARC file is still created, but contains no records.
+    assert _read_records(str(next(out.glob("site-*.warc.gz")))) == []
+
+
+def test_create_warc_gz_infers_content_type_from_extension(tmp_path):
+    """create_warc_gz sets Content-Type to image/png for .png files."""
+    img = tmp_path / "pic.png"
+    img.write_bytes(b"\x89PNG\r\n")
+    data = [
+        {"url_origin": "http://a.com/pic.png", "file": str(img), "timestamp": "20030409193011", "response": "200"},
+    ]
+    out = tmp_path / "out"
+    w.create_warc_gz(data, str(out), "site")
+
+    with open(next(out.glob("site-*.warc.gz")), "rb") as stream:
+        record = next(ArchiveIterator(stream))
+        assert record.http_headers.get_header("Content-Type") == "image/png"
+
+
+def test_create_warc_gz_invalid_timestamp_still_writes_record(tmp_path):
+    """create_warc_gz logs a bad timestamp but still writes the WARC record without a date."""
+    src = tmp_path / "page.html"
+    src.write_bytes(b"<html></html>")
+    data = [
+        {"url_origin": "http://a.com", "file": str(src), "timestamp": "not-a-date", "response": "200"},
+    ]
+    out = tmp_path / "out"
+    w.create_warc_gz(data, str(out), "site")
+    assert len(_read_records(str(next(out.glob("site-*.warc.gz"))))) == 1
+
+
+def test_create_warc_gz_splits_on_size_threshold(tmp_path):
+    """create_warc_gz starts a new part file once the size threshold is exceeded."""
+    src = tmp_path / "page.html"
+    src.write_bytes(b"x" * 200)
+    # Three entries with a 100-byte threshold force a new file before each later entry.
+    data = [
+        {"url_origin": f"http://a.com/{i}", "file": str(src), "timestamp": "20030409193011", "response": "200"}
+        for i in range(3)
+    ]
+    out = tmp_path / "out"
+    w.create_warc_gz(data, str(out), "site", max_size_bytes=100)
+    warcs = sorted(out.glob("site-*.warc.gz"))
+    assert len(warcs) >= 2
+    assert {os.path.basename(p) for p in warcs} >= {"site-0001.warc.gz", "site-0002.warc.gz"}
+
+
+# --------------------------------------------------------------------------- #
+# read_csv / process_csv_file
+# --------------------------------------------------------------------------- #
+def test_read_csv_returns_list_of_dicts(tmp_path):
+    """read_csv parses a comma-delimited CSV into a list of row dicts with string values."""
+    csv = tmp_path / "in.csv"
+    csv.write_text("a,b\n1,2\n3,4\n")
+    rows = w.read_csv(str(csv))
+    assert rows == [{"a": "1", "b": "2"}, {"a": "3", "b": "4"}]
+
+
+def test_process_csv_file_missing_file_is_noop(tmp_path):
+    """process_csv_file logs a warning and returns without error when the CSV does not exist."""
+    w.process_csv_file(str(tmp_path / "nope.csv"), str(tmp_path), "site")
+    assert list(tmp_path.glob("*.warc.gz")) == []
+
+
+def test_process_csv_file_empty_file_is_noop(tmp_path):
+    """process_csv_file skips WARC creation when the CSV contains only a header row."""
+    csv = tmp_path / "empty.csv"
+    csv.write_text("url_origin,file,timestamp,response\n")  # header only
+    w.process_csv_file(str(csv), str(tmp_path / "out"), "site")
+    assert not (tmp_path / "out").exists() or list((tmp_path / "out").glob("*.warc.gz")) == []
+
+
+def test_process_csv_file_end_to_end(tmp_path):
+    """process_csv_file reads a CSV and produces a WARC with the correct payload."""
+    page = tmp_path / "page.html"
+    page.write_bytes(b"<html>ok</html>")
+    csv = tmp_path / "in.csv"
+    csv.write_text(
+        "url_origin,file,timestamp,response\n"
+        f"http://a.com,{page},20030409193011,200\n"
+    )
+    out = tmp_path / "out"
+    w.process_csv_file(str(csv), str(out), "site")
+    records = _read_records(str(next(out.glob("site-*.warc.gz"))))
+    assert records[0][2] == b"<html>ok</html>"
+
+
+# --------------------------------------------------------------------------- #
+# combine_csv_files
+# --------------------------------------------------------------------------- #
+def test_combine_csv_files_concatenates(tmp_path):
+    """combine_csv_files merges all CSVs in a directory into a single output file."""
+    in_dir = tmp_path / "csvs"
+    in_dir.mkdir()
+    (in_dir / "a.csv").write_text("col\n1\n2\n")
+    (in_dir / "b.csv").write_text("col\n3\n")
+    out = tmp_path / "combined.csv"
+
+    w.combine_csv_files(str(in_dir), str(out))
+
+    combined = pd.read_csv(out)
+    assert combined["col"].tolist() == [1, 2, 3]
+
+
+def test_combine_csv_files_no_csvs_exits(tmp_path):
+    """combine_csv_files calls sys.exit when no CSV files are found in the directory."""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    with pytest.raises(SystemExit):
+        w.combine_csv_files(str(empty_dir), str(tmp_path / "out.csv"))


### PR DESCRIPTION
This pull request introduces a full unit test suite for the project, ensuring all core modules are covered by automated tests. It adds new testing infrastructure, updates documentation with test instructions, and configures the project for easy test execution using `pytest`.

Test setup has been made with a lot of help from opus. I have validated all the test cases.

**Testing infrastructure and coverage:**

* Added a comprehensive unit test suite in the `tests/` directory, covering all main source modules (`constants`, `utils`, `wayback_date_object`, `logging_config`, `waybackup_to_warc`, `warc_outlinks`, and `internet_archive_downloader`). The suite consists of 106 tests and does not require network access. 
* Introduced a shared `pytest` fixture in `conftest.py` to ensure tests run against the correct source code and to provide utilities for WARC file creation and stream restoration. 
* Added `pytest` as an optional dependency under the `[project.optional-dependencies]` section in `pyproject.toml`, along with `[tool.pytest.ini_options]` to configure test paths and Python path. 
